### PR TITLE
Fixed Buffer constructor.

### DIFF
--- a/src/browser-buffer.js
+++ b/src/browser-buffer.js
@@ -89,7 +89,7 @@
                         throw new Error('First argument needs to be a number, ' + 'array or string.');
                 }
 
-                if (this.length > Buffer.poolSize) {
+                if (length > Buffer.poolSize) {
                     // Big buffer, just alloc one.
                     parent = new ArrayBuffer(length);
                     offset = 0;


### PR DESCRIPTION
I was not able to instance Buffer class in Google Chrome.

E.g.:
var a = new Buffer(256);
